### PR TITLE
No history for `insertMany`

### DIFF
--- a/diffHistory.js
+++ b/diffHistory.js
@@ -148,6 +148,12 @@ var plugin = function lastModifiedPlugin(schema, options) {
     schema.pre("save", function (next) {
         var self = this;
         if(self.isNew) {
+
+            if(!self.constructor.modelName){
+                // Don't write history record when the modelName is unknown. This happens for example when using Mongoose insertMany.
+                next();
+            }
+
             var history = new History({
                 collectionName: self.constructor.modelName,
                 collectionId: self._id,

--- a/tests/diffHistory.js
+++ b/tests/diffHistory.js
@@ -296,4 +296,34 @@ describe("diffHistory", function () {
         });
     });
 
+    describe("plugin: insert many", function () {
+
+        var manySamples = [
+            {def: 'many 1', ghi: 1},
+            {def: 'many 2', ghi: 2},
+            {def: 'many 3', ghi: 3},
+            {def: 'many 4', ghi: 4},
+            {def: 'many 5', ghi: 5},
+            {def: 'many 6', ghi: 6},
+            {def: 'many 7', ghi: 7},
+            {def: 'many 8', ghi: 8}
+        ];
+
+        beforeEach(function (done) {
+            Sample1.collection.insertMany(manySamples, function(err){
+                expect(err).to.null;
+                done();
+            });
+        });
+
+        it("should not have created history records because of the bulk insertion", function (done) {
+            History.find({}, function (err, histories) {
+                expect(err).to.null;
+                expect(histories.length).equal(0);
+                done();
+            });
+        });
+
+    });
+
 });

--- a/tests/diffHistory.js
+++ b/tests/diffHistory.js
@@ -299,14 +299,14 @@ describe("diffHistory", function () {
     describe("plugin: insert many", function () {
 
         var manySamples = [
-            {def: 'many 1', ghi: 1},
-            {def: 'many 2', ghi: 2},
-            {def: 'many 3', ghi: 3},
-            {def: 'many 4', ghi: 4},
-            {def: 'many 5', ghi: 5},
-            {def: 'many 6', ghi: 6},
-            {def: 'many 7', ghi: 7},
-            {def: 'many 8', ghi: 8}
+            {def: "many 1", ghi: 1},
+            {def: "many 2", ghi: 2},
+            {def: "many 3", ghi: 3},
+            {def: "many 4", ghi: 4},
+            {def: "many 5", ghi: 5},
+            {def: "many 6", ghi: 6},
+            {def: "many 7", ghi: 7},
+            {def: "many 8", ghi: 8}
         ];
 
         beforeEach(function (done) {

--- a/tests/diffHistory.js
+++ b/tests/diffHistory.js
@@ -272,7 +272,7 @@ describe("diffHistory", function () {
                 expect(err).to.null;
                 expect(historyAudits.length).equal(2);
                 expect(historyAudits[0].commment).equal("modified def, ghi from 123 to 323");
-                expect(historyAudits[1].commment).equal("modified abc, def, _id, __v, ghi from 323 to 0");
+                expect(historyAudits[1].commment).to.contain("from 323 to 0");
                 done();
             })
         });


### PR DESCRIPTION
Hi Saurabh,

I've created this pull request, because I make heavily use of Mongoose `insertMany` function to load some initial data once my server is fired up. And as it turns out, the collection name of the document created is unknown when using `insertMany`. So this fix is meant to avoid useless (unwanted) documents in the History collection.

As it turned out, I needed to make a fix in an existing test to get them running.

Looking forward to your reply.

Regards,
Peter Kalkman