### PR TITLE
Set expandableFields default as empty array.

### DIFF
--- a/diffHistory.js
+++ b/diffHistory.js
@@ -107,6 +107,7 @@ const getDiffs = (modelName, id, cb) => {
 
 const getHistories = (modelName, id, expandableFields, cb) => {
     const histories = [];
+    expandableFields = expandableFields || [];
     return History.find({ collectionName: modelName, collectionId: id })
         .lean()
         .cursor()

--- a/tests/diffHistory.js
+++ b/tests/diffHistory.js
@@ -446,6 +446,20 @@ describe('diffHistory', function () {
                 .catch(done);
         });
 
+        it('should return histories without expandableFields', function (done) {
+            diffHistory
+                .getHistories(Sample1.modelName, sample1._id)
+                .then(historyAudits => {
+                    expect(historyAudits.length).equal(2);
+                    expect(historyAudits[0].comment).equal('modified ghi, def');
+                    expect(historyAudits[1].comment).to.equal('modified abc, __v, ghi, def, _id');
+                    expect(historyAudits[1].changedAt).not.null;
+                    expect(historyAudits[1].updatedAt).not.null;
+                    done();
+                })
+                .catch(done);
+        });
+
         it('should get version after object is removed', function (done) {
             diffHistory
                 .getVersion(Sample1, sample1._id, 1)


### PR DESCRIPTION
Otherwise this would throw an error, which is not necessarily expected.