### PR TITLE
force lean to false in saveDiffs

### DIFF
--- a/diffHistory.js
+++ b/diffHistory.js
@@ -54,6 +54,7 @@ const saveDiffHistory = (queryObject, currentObject, opts) => {
 const saveDiffs = (queryObject, opts) =>
     queryObject
         .find(queryObject._conditions)
+        .lean(false)
         .cursor()
         .eachAsync(result => saveDiffHistory(queryObject, result, opts));
 


### PR DESCRIPTION
Mongoose: ^5.1.1
If you don't force lean to false, the result of the query is a plain object and modelName is undefined