### PR TITLE
the solution of issue of (got only the updatedAt obj in diff object)

### DIFF
--- a/diffHistory.js
+++ b/diffHistory.js
@@ -45,7 +45,13 @@ const saveDiffObject = (currentObject, original, updated, opts, metaData) => {
 };
 
 const saveDiffHistory = (queryObject, currentObject, opts) => {
-    const updateParams = queryObject._update['$set'] || queryObject._update;
+  //  const updateParams = queryObject._update['$set'] || queryObject._update;
+
+    queryObject._update['updatedAt'] = queryObject._update.$set['updatedAt']
+    delete queryObject._update["$set"]
+    delete queryObject._update["$setOnInsert"]
+
+    const updateParams =  queryObject._update; 
     const dbObject = pick(currentObject, Object.keys(updateParams));
 
     return saveDiffObject(currentObject, dbObject, updateParams, opts, queryObject.options);


### PR DESCRIPTION
i have got an issue as following : 
after updating the object 
i have got the diff object has the only object (updatedAt)  and ignored the other objects, 
but after the edit i solved the issue by neglecting the $set object and get the updated parameters (queryObject._update) and then get the difference between the original one and the updated one. 
you use ||  in the code which neglect the other objects except  ($set) which contains the updatedAt only, 
