### PR TITLE
transaction support & fix upsert:true problem (modify test case to check upsert problem)

### DIFF
--- a/diffHistory.js
+++ b/diffHistory.js
@@ -81,6 +81,7 @@ const saveDiffHistory = (queryObject, currentObject, opts) => {
     return update;
   }));
   /* eslint-enable security/detect-object-injection */
+  delete queryObject._update["$setOnInsert"];
   const dbObject = pick(currentObject, Object.keys(updateParams));
   return saveDiffObject(
     currentObject,

--- a/diffHistory.js
+++ b/diffHistory.js
@@ -29,7 +29,7 @@ function checkRequired(opts, queryObject, updatedObject){
 }
 
 function saveDiffObject(currentObject, original, updated, opts, queryObject) {
-    const { __user: user, __reason: reason } = queryObject && queryObject.options || currentObject;
+    const { __user: user, __reason: reason, __session: session } = queryObject && queryObject.options || currentObject;
 
     let diff = diffPatcher.diff(
         JSON.parse(JSON.stringify(original)),
@@ -62,6 +62,10 @@ function saveDiffObject(currentObject, original, updated, opts, queryObject) {
                 reason,
                 version: lastHistory ? lastHistory.version + 1 : 0
             });
+            if (session) {
+                // console.log('history in transaction');
+                return history.save({ session });
+            }
             return history.save();
         });
 }

--- a/tests/diffHistory.js
+++ b/tests/diffHistory.js
@@ -458,15 +458,15 @@ describe('diffHistory', function () {
                 .then(() =>
                     Sample1.findOneAndUpdate(
                         { def: 'ipsum' },
-                        { ghi: 323, def: 'hey  hye' },
-                        { __user: 'Mimani', __reason: 'Mimani updated this also' }
+                        { $set: { ghi: 323, def: 'hey  hye' } },
+                        { __user: 'Mimani', __reason: 'Mimani updated this also', upsert: true }
                     )
                 )
                 .then(() => done())
                 .catch(done);
         });
 
-        it('should create a diff object when collections are updated via update', function (done) {
+        it('should create a diff object when collections are updated via update (with upsert option)', function (done) {
             History.find({}, function (err, histories) {
                 expect(err).to.null;
                 expect(histories.length).equal(1);


### PR DESCRIPTION
pass mongo session to saveHistory, so that saveHistory is part of the
transaction, and when transaction get aborted history will get rollback also.

(note: transaction need mongoose version 5.2 and above)