### PR TITLE
Fixes for findOneAndUpdate pre hook

### DIFF
--- a/diffHistory.js
+++ b/diffHistory.js
@@ -94,7 +94,6 @@ const saveDiffHistory = (queryObject, currentObject, opts) => {
 const saveDiffs = (queryObject, opts) =>
     queryObject
         .find(queryObject._conditions)
-        .lean(false)
         .cursor()
         .eachAsync(result => saveDiffHistory(queryObject, result, opts));
 

--- a/tests/diffHistory.js
+++ b/tests/diffHistory.js
@@ -99,6 +99,16 @@ mandatorySchema.plugin(diffHistory.plugin, { required: ['user', 'reason'] });
 
 const MandatorySchema = mongoose.model('mandatories', mandatorySchema);
 
+
+const schemaWithTimestamps = new mongoose.Schema(
+    {
+      def: String
+    },
+    { timestamps: true }
+  );
+schemaWithTimestamps.plugin(diffHistory.plugin);
+const TimestampsSchema = mongoose.model('timestamps', schemaWithTimestamps);
+
 describe('diffHistory', function () {
     afterEach(function (done) {
         Promise.all([
@@ -106,7 +116,8 @@ describe('diffHistory', function () {
             mongoose.connection.collections['picks'].remove({}),
             mongoose.connection.collections['samplesarrays'].remove({}),
             mongoose.connection.collections['histories'].remove({}),
-            mongoose.connection.collections['mandatories'].remove({})
+            mongoose.connection.collections['mandatories'].remove({}),
+            mongoose.connection.collections['timestamps'].remove({})
         ])
             .then(() => done())
             .catch(done);
@@ -540,6 +551,20 @@ describe('diffHistory', function () {
                 expect(updatedObj).not.to.instanceOf(Sample1);
                 done();
             }).catch(done);
+        });
+
+        it("should not fail if timestamps enabled", function (done) {
+          const timestampModel = new TimestampsSchema({ def: "hello" });
+          timestampModel.save().then(() =>
+            TimestampsSchema.findOneAndUpdate(
+              { def: "hello" },
+              { def: "update hello" }
+            )
+              .then(() => done())
+              .catch((e) => {
+                done(e);
+              })
+          );
         });
     });
 

--- a/tests/diffHistory.js
+++ b/tests/diffHistory.js
@@ -530,6 +530,17 @@ describe('diffHistory', function () {
                 })
                 .catch(done);
         });
+
+        it('should not override lean option in original query', function (done) {
+            Sample1.findOneAndUpdate(
+                { def: 'hey  hye' },
+                { ghi: 1234 },
+                { lean: true }
+            ).then(updatedObj => {
+                expect(updatedObj).not.to.instanceOf(Sample1);
+                done();
+            }).catch(done);
+        });
     });
 
     describe('plugin: pre updateOne', function () {


### PR DESCRIPTION
Hi,

This pull request fixes following things.

1. After registering plugin, findOneAndUpdate method not respecting `lean` option in original query. 

For example:

```js
const updatedModelValue = await SampleModel.findOneAndUpdate(
    { ...filterExpression },
    { ...valuesToBeChanged },
    { lean: true }
  ); // gives out updated object in plain JS object
```

After registering plugin same query returns updated mongoose model object instead of plain JS object.

2. If timestamps are enabled in mongoose schema it's throwing following error.
```js
key $set must not start with '$' 
```