### PR TITLE
Avoid storing fields that are not present in model schema

### DIFF
--- a/diffHistory.js
+++ b/diffHistory.js
@@ -79,17 +79,17 @@ function saveDiffObject(currentObject, original, updated, opts, queryObject) {
 
 const saveDiffHistory = (queryObject, currentObject, opts) => {
     const queryUpdate = queryObject.getUpdate();
-  
+
     let keysToBeModified = [];
     let mongoUpdateOperations = [];
     let plainKeys = [];
-  
+
     for (const key in queryUpdate) {
         const value = queryUpdate[key];
-        if (key.startsWith("$") && typeof value === "object") {
+        if (key.startsWith('$') && typeof value === 'object') {
             const innerKeys = Object.keys(value);
             keysToBeModified = keysToBeModified.concat(innerKeys);
-            if (key !== "$setOnInsert") {
+            if (key !== '$setOnInsert') {
                 mongoUpdateOperations = mongoUpdateOperations.concat(key);
             }
         } else {
@@ -97,14 +97,14 @@ const saveDiffHistory = (queryObject, currentObject, opts) => {
             plainKeys = plainKeys.concat(key);
         }
     }
-  
+
     const dbObject = pick(currentObject, keysToBeModified);
     const updatedObject = assign(
         dbObject,
         pick(queryUpdate, mongoUpdateOperations),
         pick(queryUpdate, plainKeys)
     );
-  
+
     return saveDiffObject(
         currentObject,
         dbObject,

--- a/diffHistory.js
+++ b/diffHistory.js
@@ -99,6 +99,7 @@ const saveDiffHistory = (queryObject, currentObject, opts) => {
     }
 
     const dbObject = pick(currentObject, keysToBeModified);
+    const validPaths = Object.keys(queryObject.model.schema.paths);
     const updatedObject = assign(
         dbObject,
         pick(queryUpdate, mongoUpdateOperations),
@@ -108,7 +109,7 @@ const saveDiffHistory = (queryObject, currentObject, opts) => {
     return saveDiffObject(
         currentObject,
         dbObject,
-        updatedObject,
+        pick(updatedObject, validPaths),
         opts,
         queryObject
     );

--- a/tests/diffHistory.js
+++ b/tests/diffHistory.js
@@ -573,7 +573,13 @@ describe('diffHistory', function () {
                 .then(() =>
                     Sample1.findOneAndUpdate(
                         { def: 'ipsum' },
-                        { $set: { ghi: 323, def: 'hey  hye' } },
+                        {
+                            $set: {
+                                ghi: 323,
+                                def: 'hey  hye',
+                                unknownKey: 'someBigObject'
+                            }
+                        },
                         {
                             __user: 'Mimani',
                             __reason: 'Mimani updated this also',
@@ -638,6 +644,18 @@ describe('diffHistory', function () {
                         done(e);
                     })
             );
+        });
+
+        it('should omit unknown/invalid keys in diff', function (done) {
+            Sample1.findById(sample1._id).then(sample => {
+                expect(sample.unknownKey).to.undefined;
+                History.find({}, function (err, histories) {
+                    expect(err).to.null;
+                    expect(histories.length).equal(1);
+                    expect(histories[0].diff.unknownKey).to.undefined;
+                    done();
+                });
+            });
         });
     });
 

--- a/tests/diffHistory.js
+++ b/tests/diffHistory.js
@@ -116,13 +116,12 @@ mandatorySchema.plugin(diffHistory.plugin, { required: ['user', 'reason'] });
 
 const MandatorySchema = mongoose.model('mandatories', mandatorySchema);
 
-
 const schemaWithTimestamps = new mongoose.Schema(
     {
-      def: String
+        def: String
     },
     { timestamps: true }
-  );
+);
 schemaWithTimestamps.plugin(diffHistory.plugin);
 const TimestampsSchema = mongoose.model('timestamps', schemaWithTimestamps);
 
@@ -619,24 +618,26 @@ describe('diffHistory', function () {
                 { def: 'hey  hye' },
                 { ghi: 1234 },
                 { lean: true }
-            ).then(updatedObj => {
-                expect(updatedObj).not.to.instanceOf(Sample1);
-                done();
-            }).catch(done);
+            )
+                .then(updatedObj => {
+                    expect(updatedObj).not.to.instanceOf(Sample1);
+                    done();
+                })
+                .catch(done);
         });
 
-        it("should not fail if timestamps enabled", function (done) {
-          const timestampModel = new TimestampsSchema({ def: "hello" });
-          timestampModel.save().then(() =>
-            TimestampsSchema.findOneAndUpdate(
-              { def: "hello" },
-              { def: "update hello" }
-            )
-              .then(() => done())
-              .catch((e) => {
-                done(e);
-              })
-          );
+        it('should not fail if timestamps enabled', function (done) {
+            const timestampModel = new TimestampsSchema({ def: 'hello' });
+            timestampModel.save().then(() =>
+                TimestampsSchema.findOneAndUpdate(
+                    { def: 'hello' },
+                    { def: 'update hello' }
+                )
+                    .then(() => done())
+                    .catch(e => {
+                        done(e);
+                    })
+            );
         });
     });
 


### PR DESCRIPTION
Hi,

Mongoose `FindOneAndUpdate` can accepts arbitrary object with unknown keys (which are not part of schema) and it updates only valid keys which are part of schema in actual DB. 
For example:
```js
const sampleSchema = new mongoose.Schema({
    key1: String,
    key2: Number
});
const Model = mongoose.models('sample', sampleSchema);
const model = new Model({ key1: 'someVal', key2: 23});
const data = await Model.findOneAndUpdate(
    { key1: 'someVal' },
    { key2: 34, unknownKey: 'bla' }
);

assert(data).equals({ key1: 'someVal', key2: 34 })
```
Mongoose doesn't store unknown keys in DB. But in diff model it will be stored as 
```js
{
    diff: {
        key2: [2, 3],
        unknownKey: ['bla']
    }
}
```
Ideally it should not save unknown keys in diff. 
